### PR TITLE
Fix doc for default values of min_bytes/max_bytes

### DIFF
--- a/doc/kafe.md
+++ b/doc/kafe.md
@@ -233,14 +233,14 @@ Options:
 * `offset :: integer()` : The offset to begin this fetch from (default : last offset for the partition)
 
 * `max_bytes :: integer()` : The maximum bytes to include in the message set for this partition. This helps bound the size of the response (default :
-1)/
+1024*1024)/
 
 * `min_bytes :: integer()` : This is the minimum number of bytes of messages that must be available to give a response. If the client sets this to 0
 the server will always respond immediately, however if there is no new data since their last request they will just get back empty message sets. If this is
 set to 1, the server will respond as soon as at least one partition has at least 1 byte of data or the specified timeout occurs. By setting higher values in
 combination with the timeout the consumer can tune for throughput and trade a little additional latency for reading only large chunks of data (e.g. setting
 MaxWaitTime to 100 ms and setting MinBytes to 64k would allow the server to wait up to 100ms to try to accumulate 64k of data before responding) (default :
-1024*1024).
+1).
 
 * `max_wait_time :: integer()` : The max wait time is the maximum amount of time in milliseconds to block waiting if insufficient data is available
 at the time the request is issued (default : 1).

--- a/src/kafe.erl
+++ b/src/kafe.erl
@@ -281,13 +281,13 @@ fetch(TopicName, Options) when is_binary(TopicName), is_map(Options) ->
 % <li><tt>partition :: integer()</tt> : The id of the partition the fetch is for (default : partition with the highiest offset).</li>
 % <li><tt>offset :: integer()</tt> : The offset to begin this fetch from (default : last offset for the partition)</li>
 % <li><tt>max_bytes :: integer()</tt> : The maximum bytes to include in the message set for this partition. This helps bound the size of the response (default :
-% 1)/</li>
+% 1024*1024)/</li>
 % <li><tt>min_bytes :: integer()</tt> : This is the minimum number of bytes of messages that must be available to give a response. If the client sets this to 0
 % the server will always respond immediately, however if there is no new data since their last request they will just get back empty message sets. If this is
 % set to 1, the server will respond as soon as at least one partition has at least 1 byte of data or the specified timeout occurs. By setting higher values in
 % combination with the timeout the consumer can tune for throughput and trade a little additional latency for reading only large chunks of data (e.g. setting
 % MaxWaitTime to 100 ms and setting MinBytes to 64k would allow the server to wait up to 100ms to try to accumulate 64k of data before responding) (default :
-% 1024*1024).</li>
+% 1).</li>
 % <li><tt>max_wait_time :: integer()</tt> : The max wait time is the maximum amount of time in milliseconds to block waiting if insufficient data is available
 % at the time the request is issued (default : 1).</li>
 % </ul>


### PR DESCRIPTION
The documented default values for min_bytes and max_bytes were reversed.
