### PR TITLE
Support partial messages at end of fetched message set

### DIFF
--- a/src/kafe_protocol_fetch.erl
+++ b/src/kafe_protocol_fetch.erl
@@ -136,8 +136,6 @@ partitions(_, _, _) ->
 message(Data) ->
   message(Data, []).
 
-message(<<>>, Acc) ->
-  lists:reverse(Acc);
 message(<<Offset:64/signed,
           MessageSize:32/signed,
           Message:MessageSize/binary,
@@ -171,7 +169,7 @@ message(<<Offset:64/signed,
                             value => Value}|Acc])
   end;
 message(_, Acc) ->
-  Acc.
+  lists:reverse(Acc).
 
 get_kv(<<KVSize:32/signed, Remainder/binary>>) when KVSize =:= -1 ->
   {<<>>, Remainder};

--- a/test/kafe_protocol_fetch_tests.erl
+++ b/test/kafe_protocol_fetch_tests.erl
@@ -8,7 +8,8 @@ kafe_protocol_fetch_test_() ->
    [
     ?_test(t_request()),
     ?_test(t_response()),
-    ?_test(t_incomplete_response())
+    ?_test(t_incomplete_response()),
+    ?_test(t_response_incomplete_final_message())
    ]
   }.
 
@@ -75,17 +76,21 @@ t_response() ->
                                              value => <<"hello world">>}],
                               partition => 0}]}]},
      kafe_protocol_fetch:response(
-       <<0, 0, 0, 1, 0, 5, 116, 111, 112, 105, 99, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-         0, 0, 5, 0, 0, 0, 185, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25, 115, 172, 247, 124, 0, 0,
-         255, 255, 255, 255, 0, 0, 0, 11, 104, 101, 108, 108, 111, 32, 119, 111, 114,
-         108, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 25, 115, 172, 247, 124, 0, 0, 255, 255,
-         255, 255, 0, 0, 0, 11, 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0,
-         0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 25, 115, 172, 247, 124, 0, 0, 255, 255, 255, 255, 0,
-         0, 0, 11, 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0, 0, 0, 0, 0, 0,
-         0, 3, 0, 0, 0, 25, 115, 172, 247, 124, 0, 0, 255, 255, 255, 255, 0, 0, 0, 11, 104,
-         101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0,
-         25, 115, 172, 247, 124, 0, 0, 255, 255, 255, 255, 0, 0, 0, 11, 104, 101, 108,
-         108, 111, 32, 119, 111, 114, 108, 100>>, 0)).
+       <<1:32                       % topic count
+           , 5:16, "topic"          % topic name
+           , 1:32                   % partition count
+             , 0:32                 % partition index
+             , 0:16                 % error code
+             , 5:64                 % highwater mark
+             , ((8+4+25)*5):32      % message set size
+                % offset, size, crc, magic, attributes, key, value
+                , 0:64, 25:32, 1940715388:32, 0, 0, -1:32, 11:32, "hello world"
+                , 1:64, 25:32, 1940715388:32, 0, 0, -1:32, 11:32, "hello world"
+                , 2:64, 25:32, 1940715388:32, 0, 0, -1:32, 11:32, "hello world"
+                , 3:64, 25:32, 1940715388:32, 0, 0, -1:32, 11:32, "hello world"
+                , 4:64, 25:32, 1940715388:32, 0, 0, -1:32, 11:32, "hello world"
+         >>, 0)).
+
 t_incomplete_response() ->
   ?assertEqual({error, incomplete_data},
                kafe_protocol_fetch:response(<<>>, 0)),
@@ -93,14 +98,45 @@ t_incomplete_response() ->
                kafe_protocol_fetch:response(<<0>>, 0)),
   ?assertEqual({error, incomplete_data},
                kafe_protocol_fetch:response(
-                 <<0, 0, 0, 1, 0, 5, 116, 111, 112, 105, 99, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                   0, 0, 5, 0, 0, 0, 185, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25, 115, 172, 247, 124, 0, 0,
-                   255, 255, 255, 255, 0, 0, 0, 11, 104, 101, 108, 108, 111, 32, 119, 111, 114,
-                   108, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 25, 115, 172, 247, 124, 0, 0, 255, 255,
-                   255, 255, 0, 0, 0, 11, 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0,
-                   0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 25, 115, 172, 247, 124, 0, 0, 255, 255, 255, 255, 0,
-                   0, 0, 11, 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0, 0, 0, 0, 0, 0,
-                   0, 3, 0, 0, 0, 25, 115, 172, 247, 124, 0, 0, 255, 255, 255, 255, 0, 0, 0, 11, 104,
-                   101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0,
-                   25, 115, 172, 247, 124, 0, 0, 255, 255, 255, 255, 0, 0, 0, 11, 104, 101, 108,
-                   108, 111, 32, 119, 111, 114, 108>>, 0)).
+                 <<1:32                       % topic count
+                     , 5:16, "topic"          % topic name
+                     , 1:32                   % partition count
+                       , 0:32                 % partition index
+                       , 0:16                 % error code
+                       , 5:64                 % highwater mark
+                       , ((8+4+25)*5):32      % message set size
+                          , 0 % message set truncated, does not match size
+                 >>, 0)).
+
+t_response_incomplete_final_message_is_ignored() ->
+  ?assertEqual(
+     {ok, [#{name => <<"topic">>,
+             partitions => [#{error_code => none,
+                              high_watermark_offset => 5,
+                              messages => [#{attributes => 0,
+                                             crc => 1940715388,
+                                             key => <<>>,
+                                             magic_byte => 0,
+                                             offset => 0,
+                                             value => <<"hello world">>},
+                                           #{attributes => 0,
+                                             crc => 1940715388,
+                                             key => <<>>,
+                                             magic_byte => 0,
+                                             offset => 1,
+                                             value => <<"hello world">>}
+                                          ],
+                              partition => 0}]}]},
+     kafe_protocol_fetch:response(
+       <<1:32                       % topic count
+           , 5:16, "topic"          % topic name
+           , 1:32                   % partition count
+             , 0:32                 % partition index
+             , 0:16                 % error code
+             , 5:64                 % highwater mark
+             , ((8+4+25)*2 + 1):32  % message set size
+                % offset, size, crc, magic, attributes, key, value
+                , 0:64, 25:32, 1940715388:32, 0, 0, -1:32, 11:32, "hello world"
+                , 1:64, 25:32, 1940715388:32, 0, 0, -1:32, 11:32, "hello world"
+                , 0 % message truncated after 1 byte
+         >>, 0)).


### PR DESCRIPTION
The protocol documentation states that:

> As an optimization the server is allowed to return a partial message at the end of the message set. Clients should handle this case.

This commit fixes the handling of such responses. Complete messages were previously returned, but in reverse order from their appearance in the response.
