### PR TITLE
Remove OTP 17 builds from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ elixir:
   - 1.3.2
   - 1.3.3
 otp_release:
+  - 19.1
   - 19.0
+  - 18.3
   - 18.1
   - 18.0
-  - 17.0
-  - 17.1
 install: true
 script:
   - mix local.rebar --force


### PR DESCRIPTION
This removes attempts to build with OTP 17, as Elixir requires OTP 18 and Travis automatically switches to OTP 18 when asked to build an Elixir project under OTP 17:

> Erlang/OTP Release 17.0 is not supported by Elixir 1.2.2. Using OTP Release 18.0.

(from https://travis-ci.org/botsunit/kafe/jobs/165549994)

Note that this change does not result in less coverage, since OTP 17 was already not being tested. If OTP 17 builds are desired, I guess the `.travis.yml` would have to go back to `language: erlang` and install Elixir manually on supported OTP versions.

This also adds the latest release of the 18.x and 19.x lines.
