### PR TITLE
Fix documentation of default required_acks value

### DIFF
--- a/src/kafe.erl
+++ b/src/kafe.erl
@@ -372,7 +372,7 @@ produce(Topic, Message) ->
 % 0 the server will not send any response (this is the only case where the server will not reply to a request). If it is 1, the server will wait the data is
 % written to the local log before sending a response. If it is -1 the server will block until the message is committed by all in sync replicas before sending a
 % response. For any number > 1 the server will block waiting for this number of acknowledgements to occur (but the server will never wait for more
-% acknowledgements than there are in-sync replicas). (default: 0)</li>
+% acknowledgements than there are in-sync replicas). (default: -1)</li>
 % <li><tt>partition :: integer()</tt> : The partition that data is being published to.</li>
 % <li><tt>key_to_partition :: fun((binary(), term()) -&gt; integer())</tt> : Hash function to do partition assignment from the message key. (default:
 % kafe:default_key_to_partition/2)</li>


### PR DESCRIPTION
`DEFAULT_PRODUCE_REQUIRED_ACKS` is actually `-1`, not `0`.
