### PR TITLE
WIP: Do not subtract 1 from offset on initial commit

### DIFF
--- a/src/kafe_consumer_committer.erl
+++ b/src/kafe_consumer_committer.erl
@@ -58,7 +58,7 @@ handle_call(remove_commits, _From, State) ->
 handle_call({offset, Offset}, _From, #state{group_id = GroupID,
                                             topic = Topic,
                                             partition = Partition} = State) ->
-  case (Offset - 1) of
+  case Offset of
     CommitOffset when CommitOffset >= 0 ->
       GenerationID = kafe_consumer_store:value(GroupID, generation_id),
       MemberID = kafe_consumer_store:value(GroupID, member_id),


### PR DESCRIPTION
Without this patch, the committed offset would always be decremented by
one on startup. This has led to situations where the offset would end up
below the lowest offset available on a partition, causing failures.

Still WIP because I haven't understood yet the (maybe good) reason for why that `- 1` was there in the first place, and I'd really like to add a test or two for the behaviour.