### PR TITLE
Broker fix

### DIFF
--- a/include/kafe.hrl
+++ b/include/kafe.hrl
@@ -1,4 +1,4 @@
--define(DEFAULT_IP, bucinet:loopback()).
+-define(DEFAULT_IP, "127.0.0.1").
 -define(DEFAULT_PORT, 9092).
 -define(DEFAULT_CLIENT_ID, <<"kafe">>).
 -define(DEFAULT_CORRELATION_ID, 0).


### PR DESCRIPTION
Do not crash if a worker terminates unexpectedly.

A broker worker process terminates whenever it receives 'tcp_closed'.
This may happen frequently if Kafka is behind a load balancer, e.g. kafe would crash on startup if Kafka is down and the LB is up.